### PR TITLE
doc: fix typos

### DIFF
--- a/installation/step3/text.md
+++ b/installation/step3/text.md
@@ -1,6 +1,6 @@
 With using `/root/profiles/demo.yaml` do the following:
 
-- Update demo.yaml [limits memory to '1Mi'](https://istio.io/latest/docs/setup/install/istioctl/#display-the-configuration-of-a-profile) for Pilot component.
+- Update demo.yaml [limits memory to '1Gi'](https://istio.io/latest/docs/setup/install/istioctl/#display-the-configuration-of-a-profile) for Pilot component.
 ```plain
 istioctl install -f /root/profiles/demo-overlay.yaml
 ```{{exec}}


### PR DESCRIPTION
The Istiod memory limit has been updated to **1Gi**, as specified in the [`demo-overlay.yaml`](https://github.com/killercoda/scenarios-ica/blob/main/installation/assets/demo-overlay.yaml#L62) file:
```yaml
    pilot:
      k8s:
        env:
          - name: PILOT_TRACE_SAMPLING
            value: "100"
        resources:
          requests:
            cpu: 0m # CHANGED
            memory: 0Mi # CHANGED
          limits:
            memory: 1Gi # CHANGED HERE
```
Furthermore, it is somewhat questionable whether Istiod is even capable of functioning with a 1Mi memory limit.